### PR TITLE
Use relative imports to resolve files when used as external dependency

### DIFF
--- a/src/components/Map.vue
+++ b/src/components/Map.vue
@@ -13,7 +13,7 @@
 </template>
 
 <script>
-import { isNumber } from '@/utils';
+import { isNumber } from '../utils';
 import { geoPath } from 'd3-geo';
 import { feature } from 'topojson-client';
 import { MapProvider } from './MapContext';

--- a/src/components/MapContext.js
+++ b/src/components/MapContext.js
@@ -1,4 +1,4 @@
-import { createContext } from '@/utils';
+import { createContext } from '../utils';
 
 const { Provider: MapProvider, Consumer: MapConsumer, $context: MapContext } = createContext({ providerName: 'MapProvider', consumerName: 'MapConsumer' });
 


### PR DESCRIPTION
I'm importing this plugin in my Nuxt.js project with:

```
import Vue from 'vue'
import VueSimpleMaps from 'vue-simple-maps'

Vue.use(VueSimpleMaps)
```

As I understand webpack only resolves the `@` alias relative to my project working directory `./src/` not `./node_modules/vue-simple-maps/src/`.