### PR TITLE
Missing cap on component name

### DIFF
--- a/packages/vue-simple-maps/README.md
+++ b/packages/vue-simple-maps/README.md
@@ -60,9 +60,9 @@ plugins: ['~/plugins/vue-simple-maps.js'];
 
 ```html
 <template>
-  <map v-if="mapData" :data="mapData" :projection="projection">
+  <Map v-if="mapData" :data="mapData" :projection="projection">
     <MapFeatures />
-  </map>
+  </Map>
 </template>
 
 <script>


### PR DESCRIPTION
Example is not working "as-is" just because of a missing cap on component name

I'm using nuxt on maybe old project but this bug could happen to other people :)

My bad: Forgot to change the examples, is it possible to change the examples as well ?